### PR TITLE
fix: clear store reference on destroy

### DIFF
--- a/.changeset/old-boxes-cross.md
+++ b/.changeset/old-boxes-cross.md
@@ -1,0 +1,5 @@
+---
+"@jaredmcateer/ngvue3": patch
+---
+
+Fix memory leak

--- a/packages/ngVue3/lib/angular/ngVueLinker.ts
+++ b/packages/ngVue3/lib/angular/ngVueLinker.ts
@@ -18,7 +18,7 @@ import { evaluateDirectives, NgVueDirective } from "../components/evaluateDirect
 import { extractSpecialAttributes } from "../components/extractSpecialAttributes";
 import { getExpressions } from "../components/getExpressions";
 import { WatchExpressionOptions, watchExpressions } from "../components/watchExpressions";
-import { getInstanceState, InstanceState } from "../instanceStore";
+import { clearInstanceState, getInstanceState, InstanceState } from "../instanceStore";
 import { NgVueService } from "./ngVueProvider";
 import { getComponentName } from "../utils/getComponentName";
 
@@ -60,6 +60,7 @@ export function ngVueLinker(
     }
     // @ts-ignore We're dereferencing this variable for garbage collection
     vueInstance = null;
+    clearInstanceState(instanceKey);
   });
 }
 

--- a/packages/ngVue3/lib/instanceStore.ts
+++ b/packages/ngVue3/lib/instanceStore.ts
@@ -24,3 +24,7 @@ export function getInstanceState(id: symbol) {
 
   return store[id];
 }
+
+export function clearInstanceState(id: symbol) {
+  delete store[id];
+}


### PR DESCRIPTION
Store was responsible for a memory leak on each ngVue instance.