### PR TITLE
Compatibility with angularjs < 1.5.0

### DIFF
--- a/.changeset/heavy-mails-teach.md
+++ b/.changeset/heavy-mails-teach.md
@@ -1,0 +1,5 @@
+---
+"@jaredmcateer/ngvue3": patch
+---
+
+Compatibility with angularjs < 1.5.0

--- a/packages/ngVue3/lib/angular/ngVueProvider.ts
+++ b/packages/ngVue3/lib/angular/ngVueProvider.ts
@@ -109,7 +109,7 @@ export function useNgVuePlugins() {
   if (!ngVuePluginsModule) {
     ngVuePluginsModule = angular
       .module("ngVue.plugins", [])
-      .provider("$ngVue", ["$injector", NgVueProvider]);
+      .provider("$ngVue", ["$injector", function($injector: ng.auto.IInjectorService) {return new NgVueProvider($injector);}]);
   }
 
   return ngVuePluginsModule.name;


### PR DESCRIPTION
Hi, I find myself having to work with a legacy project where there currently isn't agreement to upgrade from a very old angularjs version (don't ask!).  We are looking to implement new components using vue 3.

This commit fixes a problem I found where prior to angularjs 1.5.0 it wasn't possible to pass a class as a provider implementation, so for maximum compatibility we instead use a function which instantiates the class.